### PR TITLE
fix(ci): specify shell for devenv install

### DIFF
--- a/setup-devenv/action.yml
+++ b/setup-devenv/action.yml
@@ -1,7 +1,7 @@
 name: Setup Devenv
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -12,4 +12,5 @@ runs:
         name: devenv
 
     - name: Install devenv
+      shell: bash
       run: nix profile install nixpkgs#devenv


### PR DESCRIPTION
In composite actions, the `shell: ` parameter is required when using a string, as per [docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action#creating-an-action-metadata-file).

This adds that parameter when installing `devenv` in the `setup-devenv` action.