### PR TITLE
fix(ci): specify version for sccache action

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -35,4 +35,4 @@ runs:
 
     - name: Setup sccache
       if: inputs.use-sccache
-      uses: Mozilla-Actions/sccache-action
+      uses: Mozilla-Actions/sccache-action@main


### PR DESCRIPTION
The version was missing for the sccache GitHub action.