### PR TITLE
fix example test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup devenv
-        uses: andyl-technologies/andyl-github-action/setup-devenv@master
+        uses: andyl-technologies/github-actions/setup-devenv@master
 
       - name: Setup Rust cache
-        uses: andyl-technologies/andyl-github-action/rust-cache@master
+        uses: andyl-technologies/github-actions/rust-cache@master
 
       - name: Run tests
         run: devenv test
@@ -49,10 +49,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup devenv
-        uses: andyl-technologies/andyl-github-action/setup-devenv@master
+        uses: andyl-technologies/github-actions/setup-devenv@master
 
       - name: Setup Rust cache
-        uses: andyl-technologies/andyl-github-action/rust-cache@master
+        uses: andyl-technologies/github-actions/rust-cache@master
 
       - name: Run coverage tests
         run: devenv shell coverage-testing


### PR DESCRIPTION
fixes the example github action workflow in this repo after the name
switched from `andyl-github-action` to `github-actions`
