### PR TITLE
feat: add attic cache actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,45 @@ jobs:
     SCCACHE_GHA_ENABLED: 'true'
     RUSTC_WRAPPER: 'sccache'
 ```
+
+### `setup-attic`
+
+Install and configure [`attic`](https://docs.attic.rs/), a self-hosted Nix
+binary cache.
+
+Requires Nix to be installed beforehand, preferably using
+[`nix-installer-action`](https://github.com/DeterminateSystems/nix-installer-action).
+
+Example usage:
+
+```yaml
+- name: Run Nix installer
+  uses: DeterminateSystems/nix-installer-action@main
+
+- name: Use Attic cache
+  uses: andyl-technologies/github-actions/push-to-attic@master
+  with:
+    - name: andyl
+    - url: https://attic.andyl.com
+    - token: ${{ secrets.ATTIC_TOKEN }}
+```
+
+### `push-to-attic`
+
+Given a list of space-separated store paths, push them, along with all their
+dependencies to an Attic cache that has been pre-configured with the
+`setup-attic` action.
+
+This action will be no longer needed once
+[this GitHub issue](https://github.com/zhaofengli/attic/issues/233) is solved
+and the store can be watched properly.
+
+Example usage:
+
+```yaml
+- name: Push to cache
+  uses: andyl-technologies/github-actions/push-to-attic@master
+  with:
+    cache: andyl
+    paths: ./result ./result-2
+```

--- a/push-to-attic/action.yml
+++ b/push-to-attic/action.yml
@@ -1,0 +1,26 @@
+name: Push to Attic
+description: Pushes build artifacts to Attic cache
+inputs:
+  cache:
+    description: Name of cache to push to
+    required: true
+  paths:
+    description: Space-separated list of paths (e.g. ./result ./another-result)
+    required: true
+  working-directory:
+    required: false
+    default: '.'
+    description: 'Directory in which to run attic'
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: |
+        cd "${{ inputs.working-directory }}" || exit 1
+        derivers=$(nix-store --query --deriver ${{ inputs.paths }} | tr '\n' ' ')
+
+        if [[ ! "$derivers" =~ "unknown-deriver" ]]; then
+          paths_to_cache=$(nix-store --query --include-outputs $derivers --requisites | grep -v '\.drv$$' | tr '\n' ' ')
+          attic push "${{ inputs.cache }}" $paths_to_cache
+        fi

--- a/setup-attic/action.yml
+++ b/setup-attic/action.yml
@@ -1,0 +1,31 @@
+name: Setup Attic cache
+description: Login to a self-hosted Attic cache
+
+inputs:
+  name:
+    description: Name to assign for cache
+    required: true
+  url:
+    description: URL of Attic cache to use
+    required: true
+  token:
+    description: Attic CI push/pull token
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Use Attic cache
+      shell: bash
+      run: |
+        nix profile install nixpkgs#attic-client
+        attic login ${{ inputs.name }} ${{ inputs.url }} ${{ inputs.token }}
+        attic use ${{ inputs.name }}
+
+        # attic has a memory leak that prevents us from automatically
+        # looking for store outputs without Kubernetes triggering an OOM,
+        # so let's not use that here.
+        # Instead, use the `push-to-attic` action bundled in this
+        # repository.
+        # https://github.com/zhaofengli/attic/issues/233
+        # attic watch-store &


### PR DESCRIPTION
This adds common actions to configure and use a configured
[`attic`](https://docs.attic.rs) Nix binary cache. This can be used as an
alternative to Cachix for caching Nix artifacts for CI or other purposes.
