### PR TITLE
Assume `attic-client` is provided ahead of time

### DIFF
--- a/setup-attic/action.yml
+++ b/setup-attic/action.yml
@@ -18,7 +18,6 @@ runs:
     - name: Use Attic cache
       shell: bash
       run: |
-        nix profile install nixpkgs#attic-client
         attic login ${{ inputs.name }} ${{ inputs.url }} ${{ inputs.token }}
         attic use ${{ inputs.name }}
 


### PR DESCRIPTION
Our `attic-client` fork is now installed the "gha shell" see [nix-host#391].

[nix-host#391]: https://github.com/andyl-technologies/nix-host/pull/391